### PR TITLE
Steam auth

### DIFF
--- a/backend/cmd/authservice/main.go
+++ b/backend/cmd/authservice/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/scott-dang/Steam-SyncUp/internal/auth"
+)
+
+// The AuthService verifies OpenID information
+// and returns whether or not the login is valid
+// TODO: Have it generate a token for login persistence
+func main() {
+	lambda.Start(auth.Handler)
+}

--- a/backend/cmd/authservice/main.go
+++ b/backend/cmd/authservice/main.go
@@ -5,8 +5,7 @@ import (
 	"github.com/scott-dang/Steam-SyncUp/internal/auth"
 )
 
-// The AuthService verifies OpenID information
-// and returns whether or not the login is valid
+// The AuthService verifies OpenID information and returns whether the login is valid
 // TODO: Have it generate a token for login persistence
 func main() {
 	lambda.Start(auth.Handler)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,4 +2,27 @@ module github.com/scott-dang/Steam-SyncUp
 
 go 1.21.4
 
-require github.com/aws/aws-lambda-go v1.45.0 // indirect
+require (
+	github.com/aws/aws-lambda-go v1.45.0
+	github.com/aws/aws-sdk-go-v2 v1.24.1
+	github.com/aws/aws-sdk-go-v2/config v1.26.6
+	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.12.16
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.27.0
+)
+
+require (
+	github.com/aws/aws-sdk-go-v2/credentials v1.16.16 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.11 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.10 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.10 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.7.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.18.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.8.11 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.10.10 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.18.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.26.7 // indirect
+	github.com/aws/smithy-go v1.19.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,5 @@
 module github.com/scott-dang/Steam-SyncUp
 
 go 1.21.4
+
+require github.com/aws/aws-lambda-go v1.45.0 // indirect

--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"github.com/aws/aws-lambda-go/events"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+func Handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+
+	// Steam's OpenID login endpoint
+	steamLoginURL := "https://steamcommunity.com/openid/login?"
+
+	// Construct the OpenID URL with necessary parameters
+	paramsMap := request.QueryStringParameters
+	paramsMap["openid.mode"] = "check_authentication"
+
+	params := make(url.Values)
+
+	for k, v := range paramsMap {
+		params.Add(k, v)
+	}
+
+	// The URL we can utilize to verify that the user is authenticated
+	steamVerifyURL := steamLoginURL + params.Encode()
+
+	resp, err := http.Get(steamVerifyURL)
+	if err != nil {
+		return events.APIGatewayProxyResponse{
+			StatusCode: http.StatusInternalServerError,
+		}, err
+	}
+
+	// body contains "is_valid" which indicates whether it is a successful login or not
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return events.APIGatewayProxyResponse{
+			StatusCode: http.StatusInternalServerError,
+		}, err
+	}
+
+	bs := string(body)
+
+	// Logs to CloudWatch for debugging
+	log.Println("SteamVerifyURL: " + steamVerifyURL + "\n\nBody String: " + bs)
+
+	// Return the redirect response
+	return events.APIGatewayProxyResponse{
+		StatusCode: http.StatusFound,
+		Body:       bs,
+	}, nil
+}

--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -1,14 +1,51 @@
 package auth
 
 import (
-	"github.com/aws/aws-lambda-go/events"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/scott-dang/Steam-SyncUp/pkg/model"
 )
 
-func Handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+type AuthServiceResponseBody struct {
+	IsValid bool `json:"is_valid"`
+}
+
+// extractID extracts the Steam UUID from a Steam OpenID URL
+func extractID(url string) (string, error) {
+	// Simplified regular expression to match a series of digits at the end of the URL
+	re := regexp.MustCompile(`\d+$`)
+
+	id := re.FindString(url)
+	if id == "" {
+		return "", fmt.Errorf("no numeric ID found in URL")
+	}
+
+	// Check if the ID is exactly 17 digits long
+	if len(id) != 17 {
+		return "", fmt.Errorf("extracted ID is not 17 digits long")
+	}
+
+	return id, nil
+}
+
+func Handler(context context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 
 	// Steam's OpenID login endpoint
 	steamLoginURL := "https://steamcommunity.com/openid/login?"
@@ -41,14 +78,76 @@ func Handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 		}, err
 	}
 
+	// Extract Steam UUID
+	id, err := extractID(paramsMap["openid.claimed_id"])
+	if err != nil {
+		return events.APIGatewayProxyResponse{
+			StatusCode: http.StatusInternalServerError,
+		}, err
+	}
+
 	bs := string(body)
 
-	// Logs to CloudWatch for debugging
-	log.Println("SteamVerifyURL: " + steamVerifyURL + "\n\nBody String: " + bs)
+	is_valid := strings.Contains(bs, "true")
 
-	// Return the redirect response
+	// Logs to CloudWatch for debugging
+	log.Println("SteamVerifyURL: " + steamVerifyURL + "\nIs user validated? " + strconv.FormatBool(is_valid))
+
+	// Create user in DynamoDB iff valid and they don't exist yet
+	if is_valid {
+
+		// Load the config
+		config, err := config.LoadDefaultConfig(context)
+		if err != nil {
+			return events.APIGatewayProxyResponse{
+				StatusCode: http.StatusInternalServerError,
+			}, err
+		}
+
+		// Create a DynamoDB client
+		client := dynamodb.NewFromConfig(config)
+
+		userAcc := model.User{
+			SteamUUID:   id,
+			CreatedDate: time.Now().UTC().String(),
+		}
+
+		attrMap, err := attributevalue.MarshalMap(userAcc)
+		if err != nil {
+			return events.APIGatewayProxyResponse{
+				StatusCode: http.StatusInternalServerError,
+			}, err
+		}
+
+		input := &dynamodb.PutItemInput{
+			Item:                attrMap,
+			TableName:           aws.String("Users"),
+			ConditionExpression: aws.String("attribute_not_exists(SteamUUID)"),
+		}
+
+		// No-op if user already exists in the Users table
+		_, err = client.PutItem(context, input)
+		var itemAlreadyExistsErr *types.ConditionalCheckFailedException
+		if err != nil && !errors.As(err, &itemAlreadyExistsErr) {
+			return events.APIGatewayProxyResponse{
+				StatusCode: http.StatusInternalServerError,
+			}, err
+		}
+	}
+
+	responseBody, err := json.Marshal(AuthServiceResponseBody{
+		IsValid: is_valid,
+	})
+
+	if err != nil {
+		return events.APIGatewayProxyResponse{
+			StatusCode: http.StatusInternalServerError,
+		}, err
+	}
+
+	// Returns to the client a JSON string of AuthServiceResponseBody
 	return events.APIGatewayProxyResponse{
 		StatusCode: http.StatusFound,
-		Body:       bs,
+		Body:       string(responseBody),
 	}, nil
 }

--- a/backend/pkg/model/user.go
+++ b/backend/pkg/model/user.go
@@ -1,0 +1,1 @@
+package model

--- a/backend/pkg/model/user.go
+++ b/backend/pkg/model/user.go
@@ -1,1 +1,6 @@
 package model
+
+type User struct {
+	SteamUUID   string
+	CreatedDate string
+}


### PR DESCRIPTION
This service should be called after a user authenticates with steam and is redirected to a special resource on our webapp, like /auth. Then, our API is invoked (still containing the OpenID params from the callback) returning something like a token or an indicator to the client to indicate whether or not their login was successful. Every new user that signs up will have a user account created in the database.