### PR TITLE
Implement GamesService logic

### DIFF
--- a/backend/internal/games/handler.go
+++ b/backend/internal/games/handler.go
@@ -3,7 +3,10 @@ package games
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
+	"net/url"
+	"os"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/scott-dang/Steam-SyncUp/pkg/util"
@@ -12,6 +15,25 @@ import (
 type GamesServiceResponseBody struct {
 	Authenticated	bool `json:"authenticated"`
 	UUID	 		string `json:"uuid"`
+	ListOfGames struct {
+		GameCount int `json:"game_count"`
+		Games     []struct {
+			Appid                    int    `json:"appid"`
+			Name                     string `json:"name"`
+			ImgIconURL               string `json:"img_icon_url"`
+		} `json:"games"`
+	} `json:"list_of_games"`
+}
+
+type SteamGetOwnedGamesBody struct {
+	Response struct {
+		GameCount int `json:"game_count"`
+		Games     []struct {
+			Appid                    int    `json:"appid"`
+			Name                     string `json:"name"`
+			ImgIconURL               string `json:"img_icon_url"`
+		} `json:"games"`
+	} `json:"response"`
 }
 
 func Handler(context context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
@@ -25,6 +47,44 @@ func Handler(context context.Context, request events.APIGatewayProxyRequest) (ev
 	if err == nil {
 		body.Authenticated = true
 		body.UUID = user.SteamUUID
+
+    steamGetOwnedGamesAPI := "https://api.steampowered.com/IPlayerService/GetOwnedGames/v1/?"
+    steamAPIKey := os.Getenv("STEAM_API_KEY")
+
+    queryParams := url.Values{
+      "key": {steamAPIKey},
+      "steamid": {user.SteamUUID},
+      "include_appinfo": {"true"},
+      "include_played_free_games": {"true"},
+    }
+
+    steamGetOwnedGamesAPIURL := steamGetOwnedGamesAPI + queryParams.Encode()
+
+    resp, err := http.Get(steamGetOwnedGamesAPIURL)
+    if err != nil {
+      return events.APIGatewayProxyResponse{
+        StatusCode: http.StatusInternalServerError,
+      }, nil
+    }
+
+    getOwnedGamesBodyJson, err := io.ReadAll(resp.Body)
+    if err != nil {
+      return events.APIGatewayProxyResponse{
+        StatusCode: http.StatusInternalServerError,
+      }, nil
+    }
+
+    getOwnedGamesBody := SteamGetOwnedGamesBody{}
+
+    err = json.Unmarshal(getOwnedGamesBodyJson, &getOwnedGamesBody)
+
+    if err != nil {
+      return events.APIGatewayProxyResponse{
+        StatusCode: http.StatusInternalServerError,
+      }, nil
+    }
+
+    body.ListOfGames = getOwnedGamesBody.Response
 	}
 
 	responseBody, _ := json.Marshal(body)


### PR DESCRIPTION
You can try this out yourself [here](https://us-west-2.console.aws.amazon.com/lambda/home?region=us-west-2#/functions/GamesService?tab=testing)

Use this JSON and replace the specified part of the text with your JWT token (which you can get from the db table assuming you've signed in recently or from your network request response when you sign in)

{
  "headers": {
    "authorization": "Bearer *REPLACE_THIS_WITH_JWT_TOKEN"
  },
  "body": ""
}

Here is the current expected response

`{
  "statusCode": 200,
  "headers": null,
  "multiValueHeaders": null,
  "body": "{
"authenticated":true,
"uuid":"REDACTED_FOR_GITHUB_PURPOSES",
    "list_of_games":[{"game_count":156,"games":[{"appid":10,"name":"Counter- 
     Strike","img_icon_url":"6b0312cda02f5f777efa2f3318c307ff9acafbb5"}, ... all other 155 games
     ]
}}"
}`