### PR TITLE
Increase login timer to account for delay and fix default user

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -26,6 +26,8 @@ const defaultUser: User = {
 	jwttoken: "",
 	uuid: "",
 	games: [],
+  avatarfull: "",
+  personaname: "",
 };
 
 const loadSavedUser = (): User => {

--- a/frontend/src/pages/Auth.tsx
+++ b/frontend/src/pages/Auth.tsx
@@ -18,7 +18,7 @@ const authEndpointParams: URLSearchParams = new URLSearchParams(
 );
 
 function Auth() {
-	const { isLoggedIn, getAuthToken, login } = useAuth();
+	const { isLoggedIn, login, logout } = useAuth();
 	const navigate = useNavigate();
 
 	const [isLoading, setIsLoading] = useState(false);
@@ -70,10 +70,11 @@ function Auth() {
 			setIsLoading(false);
 			navigate("/");
 			alert("Login failed!");
-		}, 3500);
+      logout();
+		}, 6000);
 
 		return () => clearTimeout(authTimeout);
-	}, [navigate, login, getAuthToken, isLoggedIn]);
+	});
 
 	return (
 		<div className="bg-[#1A1A1A] h-screen flex flex-col">


### PR DESCRIPTION
Sometimes logging in can take more than the old default timer length which leads to a "Login failed!" alert despite a successful login. This increases the timer to account for that.