### PR TITLE
Attach personanames to the message on the frontend

### DIFF
--- a/frontend/src/pages/Lobbies.tsx
+++ b/frontend/src/pages/Lobbies.tsx
@@ -126,6 +126,7 @@ export default function Lobbies() {
       action: "sendmessage",
       message: inputText,
       suid: getUser().uuid,
+      personaname: getUser().personaname,
     }))
     addMessage("Me: " + inputText)
     setInputText("")


### PR DESCRIPTION
Backend currently supports usernames on messages now just in JS 
(just waiting for @EricHoelscher @Erik9113 to convert the send message handler into go)