### PR TITLE
Lobby and message patches

### DIFF
--- a/backend/internal/chatdisconnect/handler.go
+++ b/backend/internal/chatdisconnect/handler.go
@@ -23,6 +23,8 @@ func Handler(context context.Context, request events.APIGatewayWebsocketProxyReq
 		return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 	}
 
+	fmt.Println("Received request to close connection: " + connectionId)
+
 	svc := dynamodb.NewFromConfig(cfg)
 
 	item, err := svc.GetItem(context, &dynamodb.GetItemInput{

--- a/backend/internal/lobbies/handler.go
+++ b/backend/internal/lobbies/handler.go
@@ -189,7 +189,7 @@ func handleGetLobbies(context context.Context, request events.APIGatewayProxyReq
 		ExpressionAttributeValues: map[string]types.AttributeValue{
 			":a": &types.AttributeValueMemberN{Value: game},
 		},
-		ProjectionExpression: aws.String("leader, lobbyname, lobbyusers, maxusers"),
+		ProjectionExpression: aws.String("appid, leader, lobbyname, lobbyusers, maxusers, messages"),
 	})
 
 	if err != nil {

--- a/backend/pkg/model/lobby.go
+++ b/backend/pkg/model/lobby.go
@@ -1,13 +1,12 @@
 package model
 
 type Lobby struct {
-	Leader        string    `json:"leader"`
-	Appid         int       `json:"appid"`
-	LobbyName     string    `json:"lobbyname"`
-	LobbyUsers    []string  `json:"lobbyusers"`
-	MaxUsers      int       `json:"maxusers"`
-	Messages      []Message `json:"messages"`
-	ConnectionIds []string  `json:"connectionIds"`
+	Leader     string    `json:"leader"`
+	Appid      int       `json:"appid"`
+	LobbyName  string    `json:"lobbyname"`
+	LobbyUsers []string  `json:"lobbyusers"`
+	MaxUsers   int       `json:"maxusers"`
+	Messages   []Message `json:"messages"`
 }
 
 type Message struct {

--- a/frontend/src/components/createlobbyform.tsx
+++ b/frontend/src/components/createlobbyform.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useAuth } from '../context/AuthContext';
 
-export default function CreateLobbyForm({ onClose, gameId }) {
+export default function CreateLobbyForm({ onClose, gameId, fetchLobbies }) {
     const {getAuthToken} = useAuth();
 
     const [currentLobbyName, setCurrentLobbyName] = useState<string>("");
@@ -12,22 +12,22 @@ export default function CreateLobbyForm({ onClose, gameId }) {
             const createLobbyServiceEndpointURL: URL = new URL("https://hj6obivy5m.execute-api.us-west-2.amazonaws.com/default/CreateLobby")
             createLobbyServiceEndpointURL.searchParams.set("game", gameId)
             createLobbyServiceEndpointURL.searchParams.set("name", currentLobbyName)
+            // TODO: Make maxusers a user defined value
             createLobbyServiceEndpointURL.searchParams.set("maxusers", "4")
 
             console.log("Creating lobby")
             setCurrentLobbyName("")
             
-            console.log("Fetching lobbies")
             const resp = await fetch(createLobbyServiceEndpointURL, {
             headers: {
                 "authorization": "Bearer " + getAuthToken(),
             }
             });
 
-            const data = await resp.json();
-
-            if (data) {
+            // Refresh lobbies list upon success
+            if (resp.ok) {
                 console.log("Lobby creation success!")
+                await fetchLobbies(gameId)
             }
             
         } catch(err) {

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -5,13 +5,12 @@ import React, { FocusEvent, FormEvent, useState } from 'react';
 import { fetchGamesServiceAPI, Game, GamesServiceResponse, getGameImageUrl, steamOpenIdEndpointUrl } from '../utilities';
 import { useAuth } from '../context/AuthContext';
 
-export default function Header() {
+export default function Header({currentGame, setCurrentGame}) {
 
   const { getUser, getAuthToken, isLoggedIn, setupUser, logout } = useAuth();
 
   const [searchInput, setSearchInput] = useState<string>("");
   const [searchResults, setSearchResults] = useState<Game[]>([]);
-  const [selectedResult, setSelectedResult] = useState<Game | null>(null);
 
   // Used to determine the route we are on and conditionally load certain features (i.e., search bar)
   const location = useLocation();
@@ -84,7 +83,7 @@ export default function Header() {
     // Close the dropdown when clicking on a game from the dropdown
     setSearchResults([]);
 
-    setSelectedResult(game);
+    setCurrentGame(game);
   }
 
   return (
@@ -105,20 +104,20 @@ export default function Header() {
         <div className="flex flex-initial flex-row justify-items-start relative w-2/5">
           <div className="w-full">
 
-            {(location.pathname === "/lobbies" && selectedResult) ?
+            {(location.pathname === "/lobbies" && currentGame) ?
               // Replace searchbar input with selected game
               <div
                 className="flex flex-row items-center justify-center cursor-pointer w-full"
-                onClick={() => setSelectedResult(null)}
-                title={"Remove " + selectedResult.name}
+                onClick={() => setCurrentGame(null)}
+                title={"Remove " + currentGame.name}
               >
                 <img
                   className="h-12 w-12 cursor-pointer"
-                  src={getGameImageUrl(selectedResult.appid, selectedResult.img_icon_url)}
-                  alt={"Thumbnail of " + selectedResult.name}
+                  src={getGameImageUrl(currentGame.appid, currentGame.img_icon_url)}
+                  alt={"Thumbnail of " + currentGame.name}
                 />
                 <span className="text-3xl text-white text-nowrap truncate ml-5">
-                 {selectedResult.name}
+                 {currentGame.name}
                 </span>
               </div>
               :

--- a/frontend/src/hooks/useLobbySocket.tsx
+++ b/frontend/src/hooks/useLobbySocket.tsx
@@ -1,0 +1,60 @@
+import { useMemo } from "react";
+import { Message } from "../utilities";
+import useWebSocket from "./useWebSocket";
+
+// Any falsy value should be considered invalid (appid = 0, empty string, etc.)
+const isValidLobbyURL = (jwttoken: string, appid: number, leader: string) => {
+  return jwttoken && appid && leader;
+}
+
+const lobbyUrl = (jwttoken: string, appid: number, leader: string) => {
+
+  const queryParams: URLSearchParams = new URLSearchParams({
+    jwttoken: jwttoken,
+    appid:    appid.toString(),
+    leader:   leader,
+  });
+
+  const endpointUrl = new URL("wss://uvchtgqo14.execute-api.us-west-2.amazonaws.com/production/");
+  endpointUrl.search = queryParams.toString();
+
+  return endpointUrl.toString();
+}
+
+type UseLobbySocketOptions = {
+  addMessageToChat: (text: string) => void,
+}
+
+// Hook that wraps useWebSocket hook for our use case
+const useLobbySocket = (jwttoken: string, appid: number, leader: string, options: UseLobbySocketOptions) => {
+
+  const { addMessageToChat } = options;
+
+  const isValid = useMemo(() => isValidLobbyURL(jwttoken, appid, leader), [jwttoken, appid, leader])
+
+  const onMessage = (ev: MessageEvent) => {
+    try {
+      const receivedMessage: Message = JSON.parse(ev.data);
+      addMessageToChat(`${receivedMessage.personaname}: ${receivedMessage.text}`)
+    } catch (err) {
+      console.error("Error receiving message");
+    }
+  }
+
+  const { webSocketSend, isWebSocketOpen } = useWebSocket(
+    (isValid ? lobbyUrl(jwttoken, appid, leader) : ""),
+    {onMessage}
+  );
+
+  const send = (message: Message) => {
+    webSocketSend(JSON.stringify(message));
+    addMessageToChat(`${message.personaname}: ${message.text}`)
+  }
+
+  return { 
+    send: send, 
+    isOpen: isWebSocketOpen,
+  }
+}
+
+export default useLobbySocket;

--- a/frontend/src/hooks/useLobbySocket.tsx
+++ b/frontend/src/hooks/useLobbySocket.tsx
@@ -23,12 +23,13 @@ const lobbyUrl = (jwttoken: string, appid: number, leader: string) => {
 
 type UseLobbySocketOptions = {
   addMessageToChat: (text: string) => void,
+  clearChat: () => void,
 }
 
 // Hook that wraps useWebSocket hook for our use case
 const useLobbySocket = (jwttoken: string, appid: number, leader: string, options: UseLobbySocketOptions) => {
 
-  const { addMessageToChat } = options;
+  const { addMessageToChat, clearChat } = options;
 
   const isValid = useMemo(() => isValidLobbyURL(jwttoken, appid, leader), [jwttoken, appid, leader])
 
@@ -43,7 +44,10 @@ const useLobbySocket = (jwttoken: string, appid: number, leader: string, options
 
   const { webSocketSend, isWebSocketOpen } = useWebSocket(
     (isValid ? lobbyUrl(jwttoken, appid, leader) : ""),
-    {onMessage}
+    {
+      onMessage, 
+      onClose: clearChat,
+    }
   );
 
   const send = (message: Message) => {

--- a/frontend/src/hooks/useWebSocket.tsx
+++ b/frontend/src/hooks/useWebSocket.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react"
 // Custom hook that manages a user's WebSocket throughout their entire session
 const useWebSocket = (url: string, {
   onMessage,
+  onClose,
 }) => {
 
   const [socket, setSocket] = useState<WebSocket | null>(null);
@@ -40,6 +41,7 @@ const useWebSocket = (url: string, {
         console.log("WebSocket closed: abruptly");
       }
       setIsWebSocketOpen(false);
+      onClose();
     }
 
     webSocket.onopen = () => {

--- a/frontend/src/hooks/useWebSocket.tsx
+++ b/frontend/src/hooks/useWebSocket.tsx
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from "react"
+
+// Custom hook that manages a user's WebSocket throughout their entire session
+const useWebSocket = (url: string, {
+  onMessage,
+}) => {
+
+  const [socket, setSocket] = useState<WebSocket | null>(null);
+  const [isWebSocketOpen, setIsWebSocketOpen] = useState(false);
+
+  useEffect(() => {
+
+    // Always close current connection before attempting to open new one
+    if (isWebSocketOpen) {
+      setIsWebSocketOpen(false);
+      socket?.close();
+    }
+
+    // Not a proper lobby url, don't try and establish connection
+    if (!url) {
+      console.log("No lobby found to connect to");
+      return;
+    }
+
+    let webSocket: WebSocket;
+    try {
+      webSocket = new WebSocket(url);
+      setIsWebSocketOpen(true)
+    } catch (err) {
+      console.log("WebSocket failed to establish connection");
+      return;
+    }
+
+    webSocket.onmessage = onMessage;
+
+    webSocket.onclose = (ev: CloseEvent) => {
+      if (ev.wasClean) {
+        console.log("WebSocket closed: cleanly");
+      } else {
+        console.log("WebSocket closed: abruptly");
+      }
+      setIsWebSocketOpen(false);
+    }
+
+    webSocket.onopen = () => {
+      setIsWebSocketOpen(true);
+      console.log("WebSocket has opened.")
+    }
+
+    setSocket(webSocket);
+
+    return () => {
+      if (socket) {
+        socket.close();
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url]);
+
+  const webSocketSend = useCallback((message: string) => {
+    if (socket && isWebSocketOpen) {
+      socket.send(message);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [socket]);
+
+  return { webSocketSend, isWebSocketOpen };
+}
+
+export default useWebSocket;

--- a/frontend/src/pages/Lobbies.tsx
+++ b/frontend/src/pages/Lobbies.tsx
@@ -209,7 +209,6 @@ export default function Lobbies() {
 
         {/* Chat area space containing the scrolling chat area, and input box. */}
         {currentGame && currentLobbyList.some(lobby => {
-          console.log(lobby, currentGame);
           return lobby.appid === currentGame.appid && lobby.lobbyusers.includes(getUser().uuid);
         }) && (
           <div className="flex flex-col bg-grayprimary w-full border border-graysecondary rounded-3xl">

--- a/frontend/src/pages/Lobbies.tsx
+++ b/frontend/src/pages/Lobbies.tsx
@@ -26,6 +26,9 @@ export default function Lobbies() {
       addMessageToChat: (text: string) => {
         addMessage(text)
       },
+      clearChat: () => {
+        setMessages([])
+      },
     }
   );
 
@@ -84,6 +87,16 @@ export default function Lobbies() {
       }
     }
   };
+
+  const handleOldMessages = (): string[] => {
+    if (isOpen && currentGame && currentLobbyList) {
+      const lobby = getCurrentLobby(currentGame, currentLobbyList, getUser());
+      if (lobby) {
+        return lobby.messages.map(message => `${message.personaname}: ${message.text}`);
+      }
+    }
+    return [];
+  }
  
   // Add new message to chat area.
   const addMessage = (message: string) => {
@@ -194,7 +207,7 @@ export default function Lobbies() {
                 {currentGame && currentGame.name}
               </div>
 
-            <ChatArea messages={messages} chatRef={chatRef} />
+            <ChatArea messages={[...messages, ...handleOldMessages().reverse()]} chatRef={chatRef} />
 
             <InputBox
               inputText={inputText}

--- a/frontend/src/pages/Lobbies.tsx
+++ b/frontend/src/pages/Lobbies.tsx
@@ -165,7 +165,7 @@ export default function Lobbies() {
   return (
     <div className="h-screen overflow-hidden">
       {/* Header bar. */}
-      <Header />
+      <Header currentGame={currentGame} setCurrentGame={setCurrentGame}/>
 
       {/* Content space. */}
       <div className="flex flex-row h-screen text-white">

--- a/frontend/src/utilities.tsx
+++ b/frontend/src/utilities.tsx
@@ -123,6 +123,43 @@ export const steamOpenIdEndpointUrl = (): URL => {
 	return url;
 };
 
+/**
+ * Searches through all the lobbies of the current game and determines
+ * whether or not there exists a lobby that the user is in already
+ * @returns Lobby iff there exists a lobby the user is in, else undefined
+ */
+export const getCurrentLobby = (currentGame: Game | null, currentLobbyList: Lobby[], currentUser: User): Lobby | undefined => {
+  if (currentGame) {
+    const result = currentLobbyList.find(lobby => {
+
+      const sameGame = lobby.appid === currentGame.appid;
+      const hasUser = lobby.lobbyusers.includes(currentUser.uuid);
+
+      return sameGame && hasUser;
+    });
+
+    return result;
+  }
+  return undefined;
+}
+
+export interface Lobby {
+  name: string,
+  leader: string,
+  maxusers: number,
+  lobbyname: string,
+  lobbyusers: string[],
+  appid: number,
+  messages: string[],
+}
+
+export interface Message {
+  action:       string,
+  text:         string,
+  suid:         string,
+  personaname:  string,
+}
+
 export const authServiceEndpointURL: URL = new URL(
 	"https://og8ukicoij.execute-api.us-west-2.amazonaws.com/default/auth"
 );


### PR DESCRIPTION
- Refactoring mainly of WebSocket handling
- Going back to a old lobby / chat will now display chat history
- Search bar selection now selects the game on the sidebar instead of doing nothing
- Fixed case where WebSocket connections could be created too many times and not deleted enough times
- Fixed case where improper message formatting causes lobby join failure on the backend
- Fixed case where upon initial load, lobbies dont show for default game immediately until clicking to refresh lobbies
- Fixed case where chat still shows even when a user hasn't joined a lobby yet
- Fixed case where chat for a lobby in a different game still shows even when navigating into different game
- Fixed case where appId was not being returned from LobbiesService which resulted in incorrect appid of 0 (default) on frontend for every lobby